### PR TITLE
fix: make Stats text white in dark mode (#2)

### DIFF
--- a/style.css
+++ b/style.css
@@ -27,6 +27,10 @@ body.dark h1 {
   text-shadow: none;
 }
 
+body.dark h3 {
+  color: #fff   /* make stats heading white */
+}
+
 body.dark .card {
   background: #222;
   color: #ddd;


### PR DESCRIPTION
Overview
This PR fixes issue #2 where the "stats" is not turning back to white colour.

Changes
- Added dark mode CSS override for h3 to set color to white
- Comment is optional, no other logic changed

Closes #2 
